### PR TITLE
Enhance ball venom duration and wall bounce randomization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - 39 elm-test tests covering projectile creation, movement, wall reflection, corner bouncing, bounds safety, expiration, and game integration
 
 ### Changed
+- Ball venom lifetime increased from 30 ticks (3s) to 50 ticks (5s) for longer bouncing gameplay
+- Ball venom wall bounces now have a 25% chance to randomize the parallel velocity component, making trajectories less predictable
 - Shoot key changed from spacebar to Shift (prevents page scroll)
 
 ### Fixed

--- a/assets/src/Engine/Projectile.elm
+++ b/assets/src/Engine/Projectile.elm
@@ -13,7 +13,7 @@ module Engine.Projectile exposing
 Projectiles travel at 2 cells/tick in the snake's facing direction.
 Firing costs 1 segment (minimum length 3 to fire).
 5-tick cooldown between shots per snake.
-Lifetime depends on venom type (15 standard, 30 ball).
+Lifetime depends on venom type (15 standard, 50 ball).
 
 Ball venom uses velocity-based movement and bounces off walls at angles:
 - Starts moving cardinally (matching snake direction)
@@ -251,8 +251,29 @@ moveBallOneStep grid seed projectile =
 
                 else
                     ( negate vel.dx, seed1 )
+
+            -- 25% chance to randomize each component for less predictable corners
+            ( roll1, seed3 ) =
+                Random.step (Random.float 0 1) seed2
+
+            ( finalDx, seed4 ) =
+                if roll1 < 0.25 then
+                    randomSign seed3
+
+                else
+                    ( newDx, seed3 )
+
+            ( roll2, seed5 ) =
+                Random.step (Random.float 0 1) seed4
+
+            ( finalDy, seed6 ) =
+                if roll2 < 0.25 then
+                    randomSign seed5
+
+                else
+                    ( newDy, seed5 )
         in
-        ( { projectile | velocity = { dx = newDx, dy = newDy } }, seed2 )
+        ( { projectile | velocity = { dx = finalDx, dy = finalDy } }, seed6 )
 
     else if hitWallX then
         -- Hit left/right wall: flip dx, ensure dy is non-zero
@@ -260,14 +281,25 @@ moveBallOneStep grid seed projectile =
             newDx =
                 negate vel.dx
 
-            ( newDy, newSeed ) =
+            ( newDy, seed1 ) =
                 if vel.dy == 0 then
                     randomSign seed
 
                 else
                     ( vel.dy, seed )
+
+            -- 25% chance to randomize dy for less predictable bounces
+            ( roll, seed2 ) =
+                Random.step (Random.float 0 1) seed1
+
+            ( finalDy, seed3 ) =
+                if roll < 0.25 then
+                    randomSign seed2
+
+                else
+                    ( newDy, seed2 )
         in
-        ( { projectile | velocity = { dx = newDx, dy = newDy } }, newSeed )
+        ( { projectile | velocity = { dx = newDx, dy = finalDy } }, seed3 )
 
     else if hitWallY then
         -- Hit top/bottom wall: flip dy, ensure dx is non-zero
@@ -275,14 +307,25 @@ moveBallOneStep grid seed projectile =
             newDy =
                 negate vel.dy
 
-            ( newDx, newSeed ) =
+            ( newDx, seed1 ) =
                 if vel.dx == 0 then
                     randomSign seed
 
                 else
                     ( vel.dx, seed )
+
+            -- 25% chance to randomize dx for less predictable bounces
+            ( roll, seed2 ) =
+                Random.step (Random.float 0 1) seed1
+
+            ( finalDx, seed3 ) =
+                if roll < 0.25 then
+                    randomSign seed2
+
+                else
+                    ( newDx, seed2 )
         in
-        ( { projectile | velocity = { dx = newDx, dy = newDy } }, newSeed )
+        ( { projectile | velocity = { dx = finalDx, dy = newDy } }, seed3 )
 
     else
         -- No wall: move normally

--- a/assets/src/Engine/VenomType.elm
+++ b/assets/src/Engine/VenomType.elm
@@ -46,7 +46,7 @@ fromString str =
 {-| Maximum lifetime of a projectile in ticks, by venom type.
 
 StandardVenom: 15 ticks (fast, straight-line)
-BallVenom: 30 ticks (bouncing covers less ground per tick)
+BallVenom: 50 ticks (bouncing covers less ground per tick)
 -}
 maxLifetime : VenomType -> Int
 maxLifetime venomType =
@@ -55,4 +55,4 @@ maxLifetime venomType =
             15
 
         BallVenom ->
-            30
+            50

--- a/assets/src/Main.elm
+++ b/assets/src/Main.elm
@@ -1641,7 +1641,7 @@ viewInfoScreen =
                         [ h3 [] [ text "v2.2 - Venom & Power-ups - 2026-02-06" ]
                         , Html.ul []
                             [ Html.li [] [ text "Venom power-up drops: V (purple, straight) and B (blue, ball) grant venom type + 1 segment growth" ]
-                            , Html.li [] [ text "Ball venom mode with diagonal bouncing off walls" ]
+                            , Html.li [] [ text "Ball venom mode with diagonal bouncing off walls (5s lifetime, randomized bounce angles)" ]
                             , Html.li [] [ text "Local mode venom support" ]
                             , Html.li [] [ text "Shoot key changed from spacebar to Shift" ]
                             , Html.li [] [ text "Ball projectile visibility and spawn wrapping fixes" ]


### PR DESCRIPTION
## Summary
- Increased ball venom lifetime from 30 ticks (3s) to 50 ticks (5s) for longer bouncing gameplay
- Added 25% chance to randomize the parallel velocity component on diagonal/corner wall bounces, making trajectories less predictable
- Updated tests: expiration expectations (30→50), stress test duration (30→50 ticks), and new trajectory divergence test confirming different seeds produce different paths

## Test plan
- [x] `npx elm make src/Main.elm --output=/dev/null` compiles cleanly
- [x] `npx elm-test` — all 40 tests pass
- [ ] Manual: fire ball venom near a wall, observe it bouncing for ~5s with occasional angle changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)